### PR TITLE
Ability to specify an ILossFunction implementation.

### DIFF
--- a/arbiter-deeplearning4j/src/main/java/org/deeplearning4j/arbiter/layers/BaseOutputLayerSpace.java
+++ b/arbiter-deeplearning4j/src/main/java/org/deeplearning4j/arbiter/layers/BaseOutputLayerSpace.java
@@ -30,43 +30,36 @@ import java.util.List;
  */
 public abstract class BaseOutputLayerSpace<L extends BaseOutputLayer> extends FeedForwardLayerSpace<L>{
 
-    protected ParameterSpace<LossFunction> lossFunction;
-    protected ParameterSpace<ILossFunction> iLossFunction;
+    protected ParameterSpace<ILossFunction> lossFunction;
 
     protected BaseOutputLayerSpace(Builder builder){
         super(builder);
         this.lossFunction = builder.lossFunction;
-        this.iLossFunction = builder.iLossFunction;
     }
 
     protected void setLayerOptionsBuilder(BaseOutputLayer.Builder builder, double[] values){
         super.setLayerOptionsBuilder(builder,values);
         if(lossFunction != null) builder.lossFunction(lossFunction.getValue(values));
-        if(iLossFunction != null) builder.lossFunction(iLossFunction.getValue(values));
     }
 
     @Override
     public List<ParameterSpace> collectLeaves(){
         List<ParameterSpace> list = super.collectLeaves();
         if(lossFunction != null) list.addAll(lossFunction.collectLeaves());
-        if(iLossFunction != null) list.addAll(iLossFunction.collectLeaves());
         return list;
     }
 
     @SuppressWarnings("unchecked")
     public static abstract class Builder<T> extends FeedForwardLayerSpace.Builder<T>{
 
-        protected ParameterSpace<LossFunction> lossFunction;
-        protected ParameterSpace<ILossFunction> iLossFunction;
-
+        protected ParameterSpace<ILossFunction> lossFunction;
 
         public T lossFunction(LossFunction lossFunction){
             return lossFunction(new FixedValue<>(lossFunction));
         }
 
         public T lossFunction(ParameterSpace<LossFunction> lossFunction){
-            this.lossFunction = lossFunction;
-            return (T)this;
+            return iLossFunction(new LossFunctionParameterSpace(lossFunction));
         }
 
         public T iLossFunction(ILossFunction lossFunction) {
@@ -74,8 +67,42 @@ public abstract class BaseOutputLayerSpace<L extends BaseOutputLayer> extends Fe
         }
 
         public T iLossFunction(ParameterSpace<ILossFunction> lossFunction){
-            this.iLossFunction = lossFunction;
+            this.lossFunction = lossFunction;
             return (T)this;
+        }
+    }
+
+    public static class LossFunctionParameterSpace implements ParameterSpace<ILossFunction> {
+
+        private final ParameterSpace<LossFunction> lossFunctionParameterSpace;
+
+        public LossFunctionParameterSpace(ParameterSpace<LossFunction> lossFunctionParameterSpace) {
+            this.lossFunctionParameterSpace = lossFunctionParameterSpace;
+        }
+
+        @Override
+        public ILossFunction getValue(double[] parameterValues) {
+            return lossFunctionParameterSpace.getValue(parameterValues).getILossFunction();
+        }
+
+        @Override
+        public int numParameters() {
+            return lossFunctionParameterSpace.numParameters();
+        }
+
+        @Override
+        public List<ParameterSpace> collectLeaves() {
+            return lossFunctionParameterSpace.collectLeaves();
+        }
+
+        @Override
+        public boolean isLeaf() {
+            return lossFunctionParameterSpace.isLeaf();
+        }
+
+        @Override
+        public void setIndices(int... indices) {
+            lossFunctionParameterSpace.setIndices(indices);
         }
     }
 

--- a/arbiter-deeplearning4j/src/main/java/org/deeplearning4j/arbiter/layers/BaseOutputLayerSpace.java
+++ b/arbiter-deeplearning4j/src/main/java/org/deeplearning4j/arbiter/layers/BaseOutputLayerSpace.java
@@ -17,9 +17,10 @@
  */
 package org.deeplearning4j.arbiter.layers;
 
-import org.deeplearning4j.arbiter.optimize.parameter.FixedValue;
 import org.deeplearning4j.arbiter.optimize.api.ParameterSpace;
+import org.deeplearning4j.arbiter.optimize.parameter.FixedValue;
 import org.deeplearning4j.nn.conf.layers.BaseOutputLayer;
+import org.nd4j.linalg.lossfunctions.ILossFunction;
 import org.nd4j.linalg.lossfunctions.LossFunctions.LossFunction;
 
 import java.util.List;
@@ -30,21 +31,25 @@ import java.util.List;
 public abstract class BaseOutputLayerSpace<L extends BaseOutputLayer> extends FeedForwardLayerSpace<L>{
 
     protected ParameterSpace<LossFunction> lossFunction;
+    protected ParameterSpace<ILossFunction> iLossFunction;
 
     protected BaseOutputLayerSpace(Builder builder){
         super(builder);
         this.lossFunction = builder.lossFunction;
+        this.iLossFunction = builder.iLossFunction;
     }
 
     protected void setLayerOptionsBuilder(BaseOutputLayer.Builder builder, double[] values){
         super.setLayerOptionsBuilder(builder,values);
         if(lossFunction != null) builder.lossFunction(lossFunction.getValue(values));
+        if(iLossFunction != null) builder.lossFunction(iLossFunction.getValue(values));
     }
 
     @Override
     public List<ParameterSpace> collectLeaves(){
         List<ParameterSpace> list = super.collectLeaves();
         if(lossFunction != null) list.addAll(lossFunction.collectLeaves());
+        if(iLossFunction != null) list.addAll(iLossFunction.collectLeaves());
         return list;
     }
 
@@ -52,6 +57,8 @@ public abstract class BaseOutputLayerSpace<L extends BaseOutputLayer> extends Fe
     public static abstract class Builder<T> extends FeedForwardLayerSpace.Builder<T>{
 
         protected ParameterSpace<LossFunction> lossFunction;
+        protected ParameterSpace<ILossFunction> iLossFunction;
+
 
         public T lossFunction(LossFunction lossFunction){
             return lossFunction(new FixedValue<>(lossFunction));
@@ -59,6 +66,15 @@ public abstract class BaseOutputLayerSpace<L extends BaseOutputLayer> extends Fe
 
         public T lossFunction(ParameterSpace<LossFunction> lossFunction){
             this.lossFunction = lossFunction;
+            return (T)this;
+        }
+
+        public T iLossFunction(ILossFunction lossFunction) {
+            return iLossFunction(new FixedValue<>(lossFunction));
+        }
+
+        public T iLossFunction(ParameterSpace<ILossFunction> lossFunction){
+            this.iLossFunction = lossFunction;
             return (T)this;
         }
     }

--- a/arbiter-deeplearning4j/src/test/java/org/deeplearning4j/arbiter/multilayernetwork/TestLayerSpace.java
+++ b/arbiter-deeplearning4j/src/test/java/org/deeplearning4j/arbiter/multilayernetwork/TestLayerSpace.java
@@ -26,6 +26,8 @@ import org.deeplearning4j.arbiter.optimize.parameter.integer.IntegerParameterSpa
 import org.deeplearning4j.nn.conf.layers.*;
 import org.junit.Test;
 
+import java.lang.reflect.Array;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
 
@@ -92,7 +94,7 @@ public class TestLayerSpace {
 
             assertTrue(lr >= 0.3 && lr <= 0.4);
             assertTrue(l2 >= 0.01 && l2 <= 0.1 );
-            assertTrue(ArrayUtils.contains(actFns, activation));
+            assertTrue(containsActivationFunction(actFns, activation));
         }
     }
 
@@ -147,7 +149,7 @@ public class TestLayerSpace {
 
             System.out.println(activation);
 
-            assertTrue(ArrayUtils.contains(actFns, activation));
+            assertTrue(containsActivationFunction(actFns, activation));
         }
     }
 
@@ -184,7 +186,7 @@ public class TestLayerSpace {
 
             System.out.println(activation + "\t" + nOut);
 
-            assertTrue(ArrayUtils.contains(actFns, activation));
+            assertTrue(containsActivationFunction(actFns, activation));
             assertTrue(nOut >= 10 && nOut <= 20);
         }
     }
@@ -224,9 +226,16 @@ public class TestLayerSpace {
 
             System.out.println(activation + "\t" + nOut + "\t" + forgetGate);
 
-            assertTrue(ArrayUtils.contains(actFns, activation));
+            assertTrue(containsActivationFunction(actFns, activation));
             assertTrue(nOut >= 10 && nOut <= 20);
             assertTrue(forgetGate >= 0.5 && forgetGate <= 0.8);
         }
+    }
+
+    private static boolean containsActivationFunction(String[] activationFunctions, String activationFunction) {
+        for (String af : activationFunctions) {
+            if (activationFunction.startsWith(af)) return true;
+        }
+        return false;
     }
 }

--- a/arbiter-deeplearning4j/src/test/java/org/deeplearning4j/arbiter/multilayernetwork/TestMultiLayerSpace.java
+++ b/arbiter-deeplearning4j/src/test/java/org/deeplearning4j/arbiter/multilayernetwork/TestMultiLayerSpace.java
@@ -31,7 +31,10 @@ import org.deeplearning4j.nn.conf.NeuralNetConfiguration;
 import org.deeplearning4j.nn.conf.layers.DenseLayer;
 import org.deeplearning4j.nn.conf.layers.OutputLayer;
 import org.junit.Test;
+import org.nd4j.linalg.factory.Nd4j;
+import org.nd4j.linalg.lossfunctions.ILossFunction;
 import org.nd4j.linalg.lossfunctions.LossFunctions.LossFunction;
+import org.nd4j.linalg.lossfunctions.impl.LossMCXENT;
 
 import java.util.Arrays;
 import java.util.List;
@@ -60,6 +63,36 @@ public class TestMultiLayerSpace {
                 .seed(12345)
                 .addLayer(new DenseLayerSpace.Builder().nIn(10).nOut(10).build(), new FixedValue<>(2), true) //2 identical layers
                 .addLayer(new OutputLayerSpace.Builder().lossFunction(LossFunction.MCXENT).nIn(10).nOut(5).build())
+                .backprop(true).pretrain(false)
+                .build();
+
+        int nParams = mls.numParameters();
+        assertEquals(0,nParams);
+
+        MultiLayerConfiguration conf = mls.getValue(new double[0]).getMultiLayerConfiguration();
+
+        assertEquals(expected, conf);
+    }
+
+    @Test
+    public void testILossFunctionGetsSet() {
+        ILossFunction lossFunction = new LossMCXENT(Nd4j.create(new float[]{1f, 2f}));
+
+        MultiLayerConfiguration expected = new NeuralNetConfiguration.Builder()
+                .learningRate(0.005)
+                .seed(12345)
+                .list()
+                .layer(0, new DenseLayer.Builder().nIn(10).nOut(10).build())
+                .layer(1, new DenseLayer.Builder().nIn(10).nOut(10).build())
+                .layer(2, new OutputLayer.Builder().lossFunction(lossFunction).nIn(10).nOut(5).build())
+                .backprop(true).pretrain(false)
+                .build();
+
+        MultiLayerSpace mls = new MultiLayerSpace.Builder()
+                .learningRate(0.005)
+                .seed(12345)
+                .addLayer(new DenseLayerSpace.Builder().nIn(10).nOut(10).build(), new FixedValue<>(2), true) //2 identical layers
+                .addLayer(new OutputLayerSpace.Builder().iLossFunction(lossFunction).nIn(10).nOut(5).build())
                 .backprop(true).pretrain(false)
                 .build();
 


### PR DESCRIPTION
Currently BaseOutputLayerSpace doesn't support passing in custom implementations of LossFunctions.

This also support passing existing implementations with weights, for cost sensitive training.

