### PR TITLE
Exclude com.google.code.findbugs.* to avoid licensing issues

### DIFF
--- a/arbiter-core/pom.xml
+++ b/arbiter-core/pom.xml
@@ -16,12 +16,23 @@
             <groupId>org.nd4j</groupId>
             <artifactId>nd4j-api</artifactId>
             <version>${nd4j.version}</version>
+            <exclusions>
+              <exclusion>
+                <groupId>com.google.code.findbugs</groupId>
+              </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
             <groupId>org.nd4j</groupId>
             <artifactId>nd4j-jackson-reflectionloader</artifactId>
             <version>${nd4j.version}</version>
+            <exclusions>
+              <exclusion>
+                <groupId>com.google.code.findbugs</groupId>
+                <artifactId>annotations</artifactId>
+              </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
@@ -93,6 +104,12 @@
             <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-assets</artifactId>
             <version>${dropwizard.version}</version>
+            <exclusions>
+              <exclusion>
+                <groupId>com.google.code.findbugs</groupId>
+                <artifactId>jsr305</artifactId>
+              </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/arbiter-deeplearning4j/pom.xml
+++ b/arbiter-deeplearning4j/pom.xml
@@ -68,6 +68,12 @@
             <groupId>org.reflections</groupId>
             <artifactId>reflections</artifactId>
             <version>0.9.10</version>
+            <exclusions>
+              <exclusion>
+                <groupId>com.google.code.findbugs</groupId>
+                <artifactId>annotations</artifactId>
+              </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Also known as an exercise in futility, since findbugs is notoriously BSD, now
see findbugsproject/findbugs#128
But this should cut down discussion time with lawyers.