### PR TITLE
Introduces an optional profile for removing prior artifact versions of the project

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -327,6 +327,32 @@
                 </plugins>
             </build>
         </profile>
+
+        <profile>
+          <id>trimSnapshots</id>
+          <build>
+            <plugins>
+              <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>1.7</version>
+                <executions>
+                  <execution>
+                    <id>remove-old-artifacts</id>
+                    <phase>package</phase>
+                    <goals>
+                      <goal>remove-project-artifact</goal>
+                    </goals>
+                    <configuration>
+                      <removeAll>true</removeAll>
+                    </configuration>
+                  </execution>
+                </executions>
+              </plugin>
+            </plugins>
+          </build>
+        </profile>
+
     </profiles>
 
     <scm>


### PR DESCRIPTION
- essential to keep CI local repos trim
- useful for developers (esp. if reliant on mirrors)