### PR TITLE
Make lombok artifact provided in pom.xml file

### DIFF
--- a/arbiter-core/pom.xml
+++ b/arbiter-core/pom.xml
@@ -74,11 +74,5 @@
             <artifactId>jackson</artifactId>
             <version>${nd4j.version}</version>
         </dependency>
-
-        <dependency>
-            <groupId>org.projectlombok</groupId>
-            <artifactId>lombok</artifactId>
-            <version>${lombok.version}</version>
-        </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <commons.math.version>3.4.1</commons.math.version>
         <commons.lang.version>3.3.1</commons.lang.version>
         <commons.io.version>2.4</commons.io.version>
-        <lombok.version>1.16.10</lombok.version>
+        <lombok.version>1.16.20</lombok.version>
         <junit.version>4.12</junit.version>
         <slf4j.version>1.7.21</slf4j.version>
         <logback.version>1.1.2</logback.version>
@@ -86,6 +86,15 @@
         <maven-build-helper-plugin.version>3.0.0</maven-build-helper-plugin.version>
         <maven-play2-plugin.version>1.0.0-beta5</maven-play2-plugin.version>
     </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>${lombok.version}</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
 
     <profiles>
 


### PR DESCRIPTION
Fixes https://github.com/deeplearning4j/deeplearning4j/issues/4839

## What changes were proposed in this pull request?

Prevent Lombok from leaking to dependent projects, update version, and rearrange dependencies as required because no longer transitive.

## How was this patch tested?

Build passes, running LenetMnistExample from dl4j-examples works, and confirmed manually on it that `mvn dependency:tree` does not contain lombok anymore.