### PR TITLE
#159 Memory cleanup and optimizations

### DIFF
--- a/arbiter-core/src/main/java/org/deeplearning4j/arbiter/optimize/api/OptimizationResult.java
+++ b/arbiter-core/src/main/java/org/deeplearning4j/arbiter/optimize/api/OptimizationResult.java
@@ -39,8 +39,6 @@ public class OptimizationResult implements Serializable {
     @JsonProperty
     private Candidate candidate;
     @JsonProperty
-    private Object result;
-    @JsonProperty
     private Double score;
     @JsonProperty
     private int index;
@@ -51,10 +49,9 @@ public class OptimizationResult implements Serializable {
     private ResultReference resultReference;
 
 
-    public OptimizationResult(Candidate candidate, Object result, Double score, int index, Object modelSpecificResults,
+    public OptimizationResult(Candidate candidate, Double score, int index, Object modelSpecificResults,
                     CandidateInfo candidateInfo, ResultReference resultReference) {
         this.candidate = candidate;
-        this.result = result;
         this.score = score;
         this.index = index;
         this.modelSpecificResults = modelSpecificResults;

--- a/arbiter-core/src/main/java/org/deeplearning4j/arbiter/optimize/api/saving/InMemoryResultSaver.java
+++ b/arbiter-core/src/main/java/org/deeplearning4j/arbiter/optimize/api/saving/InMemoryResultSaver.java
@@ -31,8 +31,8 @@ import java.util.List;
 @NoArgsConstructor
 public class InMemoryResultSaver implements ResultSaver {
     @Override
-    public ResultReference saveModel(OptimizationResult result) throws IOException {
-        return new InMemoryResult(result);
+    public ResultReference saveModel(OptimizationResult result, Object modelResult) throws IOException {
+        return new InMemoryResult(result, modelResult);
     }
 
     @Override
@@ -48,10 +48,16 @@ public class InMemoryResultSaver implements ResultSaver {
     @AllArgsConstructor
     private static class InMemoryResult implements ResultReference {
         private OptimizationResult result;
+        private Object modelResult;
 
         @Override
         public OptimizationResult getResult() throws IOException {
             return result;
+        }
+
+        @Override
+        public Object getResultModel() throws IOException {
+            return modelResult;
         }
     }
 }

--- a/arbiter-core/src/main/java/org/deeplearning4j/arbiter/optimize/api/saving/ResultReference.java
+++ b/arbiter-core/src/main/java/org/deeplearning4j/arbiter/optimize/api/saving/ResultReference.java
@@ -33,4 +33,6 @@ public interface ResultReference {
 
     OptimizationResult getResult() throws IOException;
 
+    Object getResultModel() throws IOException;
+
 }

--- a/arbiter-core/src/main/java/org/deeplearning4j/arbiter/optimize/api/saving/ResultSaver.java
+++ b/arbiter-core/src/main/java/org/deeplearning4j/arbiter/optimize/api/saving/ResultSaver.java
@@ -37,11 +37,12 @@ public interface ResultSaver {
     /**
      * Save the model (including configuration and any additional evaluation/results)
      *
-     * @param result Results to save
-     * @return ResultReference, such that the result can be loadde back into memory
+     * @param result        Optimization result for the model to save
+     * @param modelResult   Model result to save
+     * @return ResultReference, such that the result can be loaded back into memory
      * @throws IOException If IO error occurs during model saving
      */
-    ResultReference saveModel(OptimizationResult result) throws IOException;
+    ResultReference saveModel(OptimizationResult result, Object modelResult) throws IOException;
 
     /**
      * @return The candidate types supported by this class

--- a/arbiter-core/src/main/java/org/deeplearning4j/arbiter/optimize/runner/BaseOptimizationRunner.java
+++ b/arbiter-core/src/main/java/org/deeplearning4j/arbiter/optimize/runner/BaseOptimizationRunner.java
@@ -26,14 +26,11 @@ import org.deeplearning4j.arbiter.optimize.api.Candidate;
 import org.deeplearning4j.arbiter.optimize.api.OptimizationResult;
 import org.deeplearning4j.arbiter.optimize.api.data.DataProvider;
 import org.deeplearning4j.arbiter.optimize.api.saving.ResultReference;
-import org.deeplearning4j.arbiter.optimize.api.saving.ResultSaver;
 import org.deeplearning4j.arbiter.optimize.api.score.ScoreFunction;
 import org.deeplearning4j.arbiter.optimize.api.termination.TerminationCondition;
 import org.deeplearning4j.arbiter.optimize.config.OptimizationConfiguration;
-import org.deeplearning4j.arbiter.optimize.runner.listener.StatusChangeType;
 import org.deeplearning4j.arbiter.optimize.runner.listener.StatusListener;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;

--- a/arbiter-core/src/test/java/org/deeplearning4j/arbiter/optimize/TestGridSearch.java
+++ b/arbiter-core/src/test/java/org/deeplearning4j/arbiter/optimize/TestGridSearch.java
@@ -214,7 +214,7 @@ public class TestGridSearch {
                     CandidateInfo ci = new CandidateInfo(-1, CandidateStatus.Complete, score, System.currentTimeMillis(),
                             null, null, null, null);
 
-                    return new OptimizationResult(c, candidate, score, c.getIndex(), null, ci, null);
+                    return new OptimizationResult(c, score, c.getIndex(), null, ci, null);
                 }
             };
         }

--- a/arbiter-deeplearning4j/src/main/java/org/deeplearning4j/arbiter/saver/local/FileModelSaver.java
+++ b/arbiter-deeplearning4j/src/main/java/org/deeplearning4j/arbiter/saver/local/FileModelSaver.java
@@ -76,7 +76,7 @@ public class FileModelSaver implements ResultSaver {
     }
 
     @Override
-    public ResultReference saveModel(OptimizationResult result) throws IOException {
+    public ResultReference saveModel(OptimizationResult result, Object modelResult) throws IOException {
         String dir = new File(path, result.getIndex() + "/").getAbsolutePath();
 
         File f = new File(dir);
@@ -90,7 +90,7 @@ public class FileModelSaver implements ResultSaver {
 
         FileUtils.writeStringToFile(scoreFile, String.valueOf(result.getScore()));
 
-        Model m = (Model) result.getResult();
+        Model m = (Model) modelResult;
         ModelSerializer.writeModel(m, modelFile, true);
 
 

--- a/arbiter-deeplearning4j/src/main/java/org/deeplearning4j/arbiter/saver/local/LocalFileNetResultReference.java
+++ b/arbiter-deeplearning4j/src/main/java/org/deeplearning4j/arbiter/saver/local/LocalFileNetResultReference.java
@@ -20,14 +20,11 @@ package org.deeplearning4j.arbiter.saver.local;
 import lombok.AllArgsConstructor;
 import org.apache.commons.io.FileUtils;
 import org.deeplearning4j.arbiter.DL4JConfiguration;
-import org.deeplearning4j.arbiter.GraphConfiguration;
 import org.deeplearning4j.arbiter.optimize.api.Candidate;
 import org.deeplearning4j.arbiter.optimize.api.OptimizationResult;
 import org.deeplearning4j.arbiter.optimize.api.saving.ResultReference;
 import org.deeplearning4j.earlystopping.EarlyStoppingConfiguration;
 import org.deeplearning4j.nn.api.Model;
-import org.deeplearning4j.nn.graph.ComputationGraph;
-import org.deeplearning4j.nn.multilayer.MultiLayerNetwork;
 import org.deeplearning4j.util.ModelSerializer;
 
 import java.io.File;
@@ -54,13 +51,6 @@ public class LocalFileNetResultReference implements ResultReference {
     @Override
     public OptimizationResult getResult() throws IOException {
 
-        Model m;
-        if (isGraph) {
-            m = ModelSerializer.restoreComputationGraph(modelFile, false);
-        } else {
-            m = ModelSerializer.restoreMultiLayerNetwork(modelFile, false);
-        }
-
 
         String scoreStr = FileUtils.readFileToString(scoreFile);
         //TODO: properly parsing. Probably want to store additional info other than just score...
@@ -80,15 +70,6 @@ public class LocalFileNetResultReference implements ResultReference {
             nEpochs = Integer.parseInt(numEpochs);
         }
 
-        Object dl4jConfiguration;
-        if (isGraph) {
-            dl4jConfiguration = new GraphConfiguration(((ComputationGraph) m).getConfiguration(),
-                            earlyStoppingConfiguration, nEpochs);
-        } else {
-            dl4jConfiguration = new DL4JConfiguration(((MultiLayerNetwork) m).getLayerWiseConfigurations(),
-                            earlyStoppingConfiguration, nEpochs);
-        }
-
 
 
         Object additionalResults;
@@ -102,7 +83,18 @@ public class LocalFileNetResultReference implements ResultReference {
             additionalResults = null;
         }
 
-        return new OptimizationResult(candidate, m, d, index, additionalResults, null, this);
+        return new OptimizationResult(candidate, d, index, additionalResults, null, this);
+    }
+
+    @Override
+    public Object getResultModel() throws IOException {
+        Model m;
+        if (isGraph) {
+            m = ModelSerializer.restoreComputationGraph(modelFile, false);
+        } else {
+            m = ModelSerializer.restoreMultiLayerNetwork(modelFile, false);
+        }
+        return m;
     }
 
     @Override

--- a/arbiter-deeplearning4j/src/test/java/org/deeplearning4j/arbiter/multilayernetwork/TestErrors.java
+++ b/arbiter-deeplearning4j/src/test/java/org/deeplearning4j/arbiter/multilayernetwork/TestErrors.java
@@ -47,7 +47,7 @@ public class TestErrors {
                 .candidateGenerator(candidateGenerator).dataProvider(new TestDataProviderMnist(32, 10))
                 .modelSaver(new FileModelSaver(f)).scoreFunction(new TestSetLossScoreFunction(true))
                 .terminationConditions(
-                        new MaxCandidatesCondition(10))
+                        new MaxCandidatesCondition(5))
                 .build();
 
         IOptimizationRunner runner = new LocalOptimizationRunner(configuration);
@@ -74,7 +74,7 @@ public class TestErrors {
                 .candidateGenerator(candidateGenerator).dataProvider(new TestDataProviderMnist(32, 10))
                 .modelSaver(new FileModelSaver(f)).scoreFunction(new TestSetLossScoreFunction(true))
                 .terminationConditions(
-                        new MaxCandidatesCondition(10))
+                        new MaxCandidatesCondition(5))
                 .build();
 
         IOptimizationRunner runner = new LocalOptimizationRunner(configuration);
@@ -102,7 +102,7 @@ public class TestErrors {
         OptimizationConfiguration configuration = new OptimizationConfiguration.Builder()
                 .candidateGenerator(candidateGenerator).dataProvider(new TestDataProviderMnist(32, 10))
                 .modelSaver(new FileModelSaver(f)).scoreFunction(new TestSetLossScoreFunction(true))
-                .terminationConditions(new MaxCandidatesCondition(10))
+                .terminationConditions(new MaxCandidatesCondition(5))
                 .build();
 
         IOptimizationRunner runner = new LocalOptimizationRunner(configuration);
@@ -130,7 +130,7 @@ public class TestErrors {
                 .candidateGenerator(candidateGenerator).dataProvider(new TestDataProviderMnist(32, 10))
                 .modelSaver(new FileModelSaver(f)).scoreFunction(new TestSetLossScoreFunction(true))
                 .terminationConditions(
-                        new MaxCandidatesCondition(10))
+                        new MaxCandidatesCondition(5))
                 .build();
 
         IOptimizationRunner runner = new LocalOptimizationRunner(configuration, new MultiLayerNetworkTaskCreator());

--- a/arbiter-deeplearning4j/src/test/java/org/deeplearning4j/arbiter/multilayernetwork/TestScoreFunctions.java
+++ b/arbiter-deeplearning4j/src/test/java/org/deeplearning4j/arbiter/multilayernetwork/TestScoreFunctions.java
@@ -95,7 +95,7 @@ public class TestScoreFunctions {
                     testIter.setPreProcessor(new PreProc(rocType));
 
                     OptimizationResult or = rr.getResult();
-                    MultiLayerNetwork net = (MultiLayerNetwork) or.getResult();
+                    MultiLayerNetwork net = (MultiLayerNetwork) or.getResultReference().getResultModel();
 
                     double expScore;
                     switch (rocType){


### PR DESCRIPTION
Fixes: https://github.com/deeplearning4j/Arbiter/issues/159

Allows models to be GC'd as soon as model saving is complete.
Also destroys workspaces manually to ensure their memory will be deallocated ASAP.