### PR TITLE
Fix timestamp race condition that could impact rendered UI results

### DIFF
--- a/arbiter-core/src/main/java/org/deeplearning4j/arbiter/optimize/runner/BaseOptimizationRunner.java
+++ b/arbiter-core/src/main/java/org/deeplearning4j/arbiter/optimize/runner/BaseOptimizationRunner.java
@@ -149,6 +149,7 @@ public abstract class BaseOptimizationRunner implements IOptimizationRunner {
                     //Failed on generation...
                     status = processFailedCandidates(candidate);
                 } else {
+                    long created = System.currentTimeMillis();
                     ListenableFuture<OptimizationResult> f =
                             execute(candidate, config.getDataProvider(), config.getScoreFunction());
                     f.addListener(new OnCompletionListener(f), futureListenerExecutor);
@@ -156,7 +157,7 @@ public abstract class BaseOptimizationRunner implements IOptimizationRunner {
                     totalCandidateCount.getAndIncrement();
 
                     status = new CandidateInfo(candidate.getIndex(), CandidateStatus.Created, null,
-                            System.currentTimeMillis(), null, null, candidate.getFlatParameters(), null);
+                            created, null, null, candidate.getFlatParameters(), null);
                     currentStatus.put(candidate.getIndex(), status);
                 }
 


### PR DESCRIPTION
Fixes an issue where the UI would return empty results for the first model due to wrong timestamp being used.